### PR TITLE
Reproduce Bitcoin Core's handling of cookie files

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,3 +27,6 @@ jsonrpc = "0.13.0"
 # Used for deserialization of JSON.
 serde = "1"
 serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -10,6 +10,7 @@
 
 use std::collections::HashMap;
 use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::iter::FromIterator;
 use std::path::PathBuf;
 use std::{fmt, result};
@@ -197,20 +198,16 @@ pub enum Auth {
 impl Auth {
     /// Convert into the arguments that jsonrpc::Client needs.
     pub fn get_user_pass(self) -> Result<(Option<String>, Option<String>)> {
-        use std::io::Read;
         match self {
             Auth::None => Ok((None, None)),
             Auth::UserPass(u, p) => Ok((Some(u), Some(p))),
-            Auth::CookieFile(path) => {
-                let mut file = File::open(path)?;
-                let mut contents = String::new();
-                file.read_to_string(&mut contents)?;
-                let mut split = contents.splitn(2, ":");
-                Ok((
-                    Some(split.next().ok_or(Error::InvalidCookieFile)?.into()),
-                    Some(split.next().ok_or(Error::InvalidCookieFile)?.into()),
-                ))
-            }
+            Auth::CookieFile(path) => BufReader::new(File::open(path)?)
+                .lines()
+                .next()
+                .ok_or(Error::InvalidCookieFile)??
+                .split_once(':')
+                .map(|(user, pass)| (Some(user.into()), Some(pass.into())))
+                .ok_or(Error::InvalidCookieFile),
         }
     }
 }
@@ -1356,5 +1353,35 @@ mod tests {
     #[test]
     fn test_handle_defaults() {
         test_handle_defaults_inner().unwrap();
+    }
+
+    #[test]
+    fn auth_cookie_file_ignores_newline() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("cookie");
+        std::fs::write(&path, "foo:bar\n").unwrap();
+        assert_eq!(
+            Auth::CookieFile(path).get_user_pass().unwrap(),
+            (Some("foo".into()), Some("bar".into())),
+        );
+    }
+
+    #[test]
+    fn auth_cookie_file_ignores_additional_lines() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("cookie");
+        std::fs::write(&path, "foo:bar\nbaz").unwrap();
+        assert_eq!(
+            Auth::CookieFile(path).get_user_pass().unwrap(),
+            (Some("foo".into()), Some("bar".into())),
+        );
+    }
+
+    #[test]
+    fn auth_cookie_file_fails_if_colon_isnt_present() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("cookie");
+        std::fs::write(&path, "foobar").unwrap();
+        assert!(matches!(Auth::CookieFile(path).get_user_pass(), Err(Error::InvalidCookieFile)));
     }
 }


### PR DESCRIPTION
Bitcoin Core uses a single call to std::getline to read the contents of cookie files, making it ignore newlines in the file, as well as ignore any lines after the first. This reproduces that behavior, so that all cookie files that work with Bitcoin Core should work with this library.